### PR TITLE
Add createMovie endpoint and update movie routes

### DIFF
--- a/src/handlers/movies/createMovie.ts
+++ b/src/handlers/movies/createMovie.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from "express";
+import prismadb from "../../lib/prismadb";
+import { Movie } from "@prisma/client";
+
+const createMovie = async(request: Request<{}, {}, Movie>, response: Response)=>{
+    const movie = request.body;
+    await prismadb.movie.create({ data: movie });
+    response.status(201).send(movie);
+}
+
+export default createMovie;

--- a/src/handlers/movies/createMovie.ts
+++ b/src/handlers/movies/createMovie.ts
@@ -4,8 +4,8 @@ import { Movie } from "@prisma/client";
 
 const createMovie = async(request: Request<{}, {}, Movie>, response: Response)=>{
     const movie = request.body;
-    await prismadb.movie.create({ data: movie });
-    response.status(201).send(movie);
+    const newMovie = await prismadb.movie.create({ data: movie });
+    response.status(201).send(newMovie);
 }
 
 export default createMovie;

--- a/src/handlers/movies/updateMovie.ts
+++ b/src/handlers/movies/updateMovie.ts
@@ -5,11 +5,11 @@ import { Movie } from "@prisma/client";
 const updateMovie = async (request: Request<{ id: string }, {}, Movie>, response: Response) => {
     const { id } = request.params;
     const update = request.body;
-    await prismadb.movie.update({
+    const updatedMovie = await prismadb.movie.update({
         where: { id },
         data: update
     })
-    response.status(201).send(movie);
+    response.status(201).send(updatedMovie);
 }
 
 export default updateMovie;

--- a/src/handlers/movies/updateMovie.ts
+++ b/src/handlers/movies/updateMovie.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from "express";
+import prismadb from "../../lib/prismadb";
+import { Movie } from "@prisma/client";
+
+const updateMovie = async (request: Request<{ id: string }, {}, Movie>, response: Response) => {
+    const { id } = request.params;
+    const update = request.body;
+    await prismadb.movie.update({
+        where: { id },
+        data: update
+    })
+    response.status(201).send(movie);
+}
+
+export default updateMovie;

--- a/src/routes/movies.ts
+++ b/src/routes/movies.ts
@@ -6,6 +6,7 @@ import deleteMovie from "../handlers/movies/deleteMovie";
 import getRandomMovie from "../handlers/movies/getRandomMovie";
 import getMovieById from "../handlers/movies/getMovieById";
 import getAllMovies from "../handlers/movies/getAllMovies";
+import createMovie from "../handlers/movies/createMovie";
 
 
 // Import Middlewares
@@ -21,8 +22,8 @@ const router = Router();
 router.get("/", authenticateToken("admin"), asyncHandler(getAllMovies));
 
 // Create from File
-router.post("/create", authenticateToken("admin"), async(req: Request, res: Response)=>{
-    
+router.post("/create", authenticateToken("admin"), async (req: Request, res: Response) => {
+
     const movies = await prismadb.movie.createMany({
         data: Movies
     })
@@ -30,8 +31,10 @@ router.post("/create", authenticateToken("admin"), async(req: Request, res: Resp
 })
 
 // Create New Movie
+router.post("/", authenticateToken("admin"), asyncHandler(createMovie))
 
 // Update A Movie
+router.put("/:id", authenticateToken("admin"), asyncHandler(createMovie))
 
 // GET Random Movie
 router.get("/random", authenticateToken(), asyncHandler(getRandomMovie))


### PR DESCRIPTION
This pull request adds a new endpoint for creating movies and updates the movie routes to include the new endpoint. The createMovie endpoint allows users with admin privileges to create a new movie by sending a POST request to the /movies/create endpoint. Additionally, the movie routes have been updated to include the createMovie endpoint and to handle the updating of movies. This pull request improves the functionality of the movie routes and enhances the overall user experience.